### PR TITLE
Change strophe dependency name to strophe.js

### DIFF
--- a/strophe.ping.js
+++ b/strophe.ping.js
@@ -15,7 +15,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([
-            "strophe"
+            "strophe.js"
         ], function (Strophe) {
             factory(
                 Strophe.Strophe,


### PR DESCRIPTION
@cmrd-senya explains in [this issue](https://github.com/strophe/strophejs-plugin-ping/issues/1) the problem he faced with the strophe dependency name inconsistency.

I run against a similar problem when I used the plugin in my `ReactJS` app. When I import 'strophe-plugin-ping', I get:
```
Module not found: Can't resolve 'strophe' in '[root]\node_modules\strophejs-plugin-ping'
```
This PR changes the dependency name to match the package name of `strophe.js`

fix https://github.com/strophe/strophejs-plugin-ping/issues/1