### PR TITLE
Mark compatibility with Strope 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/strophe/strophejs-plugin-ping#readme",
   "peerDependencies": {
-    "strophe.js": "^1.2.12 || ^2.0.0"
+    "strophe.js": "^1.2.12 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "rollup": "^0.67.3"


### PR DESCRIPTION
Per the release notes for Strophe 3.0, the only potentially breaking change was modifying internal structure which might affect some deep imports, but this package only imports directly from 'strophe.js' so should be unaffected.